### PR TITLE
[17] Add functions that provide WorkerId to worker sub-routines

### DIFF
--- a/src/Control/Concurrent/Capataz/Internal/Worker.hs
+++ b/src/Control/Concurrent/Capataz/Internal/Worker.hs
@@ -31,7 +31,7 @@ workerMain env@ParentSupervisorEnv { supervisorNotify } workerOptions@WorkerOpti
     workerCreationTime <- getCurrentTime
     workerAsync        <- asyncWithUnmask $ \unmask -> do
       Util.setProcessThreadName workerId workerName
-      eResult     <- unsafeTry $ unmask workerAction
+      eResult     <- unsafeTry $ unmask (workerAction workerId)
 
       resultEvent <- case eResult of
         Left err -> Process.handleProcessException unmask


### PR DESCRIPTION
Now workers can reference their `WorkerId` which works great for tracing purposes, as it allows to correlate events happening in this worker with that identifier